### PR TITLE
Add colorized man pages

### DIFF
--- a/bashrc.symlink
+++ b/bashrc.symlink
@@ -6,6 +6,21 @@ export PATH=$homebrew:$PATH
 unset homebrew
 
 # ------------------------------------------------------------------------------
+# Colorized Manual Pages
+# (Ref.: http://nion.modprobe.de/blog/archives/572-less-colors-for-man-pages.html)
+# ------------------------------------------------------------------------------
+man() {
+    env LESS_TERMCAP_mb=$(printf "\e[1;31m") \
+    LESS_TERMCAP_md=$(printf "\e[1;31m") \
+    LESS_TERMCAP_me=$(printf "\e[0m") \
+    LESS_TERMCAP_se=$(printf "\e[0m") \
+    LESS_TERMCAP_so=$(printf "\e[1;44;33m") \
+    LESS_TERMCAP_ue=$(printf "\e[0m") \
+    LESS_TERMCAP_us=$(printf "\e[1;32m") \
+    man "$@"
+}
+
+# ------------------------------------------------------------------------------
 # Executable python scripts will be put in:
 #   /usr/local/share/python
 # so you may want to put "/usr/local/share/python" in your PATH, too.


### PR DESCRIPTION
Make bash manual pages colorful using less as suggested here:
http://nion.modprobe.de/blog/archives/572-less-colors-for-man-pages.html
- Add less colors to man pages
